### PR TITLE
chore: update workflow references to upstream tooling

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -80,4 +80,4 @@ jobs:
        github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
-    uses: hdamker/tooling/.github/workflows/release-automation-reusable.yml@validation-framework
+    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@validation-framework

--- a/.github/workflows/validation-caller.yml
+++ b/.github/workflows/validation-caller.yml
@@ -31,5 +31,5 @@ permissions:
 
 jobs:
   validation:
-    uses: hdamker/tooling/.github/workflows/validation.yml@validation-framework
+    uses: camaraproject/tooling/.github/workflows/validation.yml@validation-framework
     secrets: inherit

--- a/code/Test_definitions/sample-service-createResource.feature
+++ b/code/Test_definitions/sample-service-createResource.feature
@@ -1,0 +1,39 @@
+Feature: CAMARA Sample Service API, vwip - Operation: createResource
+
+  # Input to be provided by the implementation to the tests
+  # References to OAS spec schemas refer to schemas specified in /code/API_definitions/sample-service.yaml
+  # Implementation indications:
+  # * api_root: API root of the server URL
+  #
+  # Testing assets:
+  # * A valid access token with scope sample-service:resource:write
+
+  Background: Common Sample Service createResource setup
+    Given an environment at "apiRoot"
+    And the resource "/sample-service/vwip/resources"
+    And the header "Authorization" is set to a valid access token
+    And the header "Content-Type" is set to "application/json"
+
+  # Success scenarios
+
+  @SampleService_createResource_201.01_success
+  Scenario: Create resource successfully
+    Given the request body is set to a valid CreateResource request
+    When the HTTPS "POST" request is sent
+    Then the response status code is 201
+    And the response header "Content-Type" is "application/json"
+    And the response header "x-correlator" has same value as the request header "x-correlator"
+    And the response property "$.resourceId" exists
+    And the response property "$.name" exists
+
+  # Error scenarios
+
+  @SampleService_createResource_400.01_invalid_request
+  Scenario: Error response for invalid request body
+    Given the request body is set to an invalid CreateResource request
+    When the HTTPS "POST" request is sent
+    Then the response status code is 400
+    And the response header "Content-Type" is "application/json"
+    And the response property "$.status" is 400
+    And the response property "$.code" is "INVALID_ARGUMENT"
+    And the response property "$.message" exists


### PR DESCRIPTION
#### What type of PR is this?

repository management, tests

#### What this PR does / why we need it:

Updates the validation and release automation caller workflows to reference `camaraproject/tooling@validation-framework` (upstream) instead of `hdamker/tooling@validation-framework` (fork). This is needed because the `validation-framework` branch has been published to upstream tooling for integration testing.

Also adds a minimal gherkin test definition for the sample-service API to enable validation framework testing of the gherkin-lint engine across both APIs.

#### Which issue(s) this PR fixes:

Part of validation framework v1 integration testing (ReleaseManagement#448).

#### Special notes for reviewers:

The `validation-framework` branch now exists on `camaraproject/tooling`. This PR makes the test repo reference that upstream branch instead of the fork.

#### Changelog input

```
 release-note
N/A (test infrastructure)
```

#### Additional documentation

```
docs
N/A
```