### PR TITLE
fix: restore secrets: inherit for release automation caller

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -81,3 +81,4 @@ jobs:
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
     uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@validation-framework
+    secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Restores the `secrets: inherit` line that was accidentally dropped from the release automation caller workflow during the workflow reference update in PR #54. Without this, org secrets (`RELEASE_APP_PRIVATE_KEY`) are not passed to the reusable workflow, causing the app token generation to fail.

#### Which issue(s) this PR fixes:

Fixes the RA sync-issue failure in [run 23841651156](https://github.com/camaraproject/ReleaseTest/actions/runs/23841651156).

#### Special notes for reviewers:

One-line fix. The validation caller was not affected because it already had `secrets: inherit`.

#### Changelog input

```
 release-note
N/A
```

#### Additional documentation

```
docs
N/A
```