### PR TITLE
fix: align API definitions with Design Guide and Commonalities artifacts

### DIFF
--- a/code/API_definitions/release-test.yaml
+++ b/code/API_definitions/release-test.yaml
@@ -5,22 +5,25 @@ info:
     Minimal test definition for validating the CAMARA release automation workflow.
     This is not a real API — it exists solely for end-to-end testing.
   version: wip
-  x-camara-commonalities: 0.6
+  x-camara-commonalities: 0.7.0
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/TestRepo
+  url: https://github.com/camaraproject/ReleaseTest
 servers:
   - url: "{apiRoot}/release-test/vwip"
     variables:
       apiRoot:
-        default: https://localhost:443
-        description: API root
+        default: http://localhost:9091
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
   - name: Status
     description: Service status operations
+security:
+  - openId:
+      - release-test:status:read
 paths:
   /status:
     get:
@@ -29,15 +32,123 @@ paths:
       description: Returns the current status of the release test service.
       tags:
         - Status
+      parameters:
+        - $ref: "#/components/parameters/x-correlator"
       responses:
         "200":
           description: Service is running
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    enum:
-                      - available
+                $ref: "#/components/schemas/ServiceStatus"
+        "401":
+          description: Unauthorized
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ErrorInfo"
+                  - type: object
+                    properties:
+                      status:
+                        enum:
+                          - 401
+                      code:
+                        enum:
+                          - UNAUTHENTICATED
+              examples:
+                GENERIC_401_UNAUTHENTICATED:
+                  description: Request cannot be authenticated and a new authentication is required
+                  value:
+                    status: 401
+                    code: UNAUTHENTICATED
+                    message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
+        "403":
+          description: Forbidden
+          headers:
+            x-correlator:
+              $ref: "#/components/headers/x-correlator"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ErrorInfo"
+                  - type: object
+                    properties:
+                      status:
+                        enum:
+                          - 403
+                      code:
+                        enum:
+                          - PERMISSION_DENIED
+              examples:
+                GENERIC_403_PERMISSION_DENIED:
+                  description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+                  value:
+                    status: 403
+                    code: PERMISSION_DENIED
+                    message: Client does not have sufficient permissions to perform this action.
+components:
+  securitySchemes:
+    openId:
+      type: openIdConnect
+      openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      description: OpenID Connect authentication via discovery metadata.
+  parameters:
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
+      schema:
+        $ref: "#/components/schemas/XCorrelator"
+  headers:
+    x-correlator:
+      description: Correlation id for the different services
+      schema:
+        $ref: "#/components/schemas/XCorrelator"
+  schemas:
+    XCorrelator:
+      type: string
+      description: Correlator string, UUID format recommended but any string matching the pattern can be used
+      pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
+      maxLength: 256
+      example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+    ServiceStatus:
+      type: object
+      description: Current service status
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: Availability of the service
+          enum:
+            - available
+    ErrorInfo:
+      type: object
+      description: A structured error response providing details about a failed request, including the HTTP status code, an error code, and a human-readable message
+      required:
+        - status
+        - code
+        - message
+      properties:
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: HTTP response status code
+        code:
+          type: string
+          maxLength: 96
+          description: A human-readable code to describe the error
+        message:
+          type: string
+          maxLength: 512
+          description: A human-readable description of what the event represents

--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Sample CAMARA Service API
+  title: Sample Service
   description: |
     Template for a request-response CAMARA API.
 
@@ -18,12 +18,15 @@ info:
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
   x-camara-commonalities: 0.7.0
+externalDocs:
+  description: Product documentation at CAMARA
+  url: https://github.com/camaraproject/ReleaseTest
 servers:
   - url: "{apiRoot}/sample-service/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091
-        description: API root, Apache 2.0 licensed
+        description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
   - name: Resources
     description: Operations on sample resources
@@ -89,6 +92,8 @@ paths:
             application/json:
               schema:
                 type: array
+                minItems: 0
+                maxItems: 1000
                 items:
                   $ref: "#/components/schemas/Resource"
         "401":
@@ -202,6 +207,7 @@ components:
     ResourceId:
       type: string
       format: uuid
+      maxLength: 36
       description: Unique identifier for the resource
     CreateResource:
       description: Properties for creating a new resource

--- a/code/common/CAMARA_common.yaml
+++ b/code/common/CAMARA_common.yaml
@@ -1,20 +1,25 @@
-openapi: 3.0.3
 info:
   title: CAMARA common data types
-  description: Common data types for CAMARA APIs
+  description: |
+    Common data types for CAMARA APIs.
+    This file contains Commonalities-owned schemas that are identical across all
+    CAMARA APIs, including error responses, common parameters, headers, and
+    reusable data types.
+
+    API repositories place this file in `code/common/` and reference schemas
+    via `$ref: "../common/CAMARA_common.yaml#/components/schemas/<SchemaName>"`.
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.8.0-rc.1
-
+  version: wip
   x-camara-commonalities: 0.7.0
 
-paths: {}
 components:
   securitySchemes:
     openId:
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
+      description: OpenID Connect authentication via discovery metadata.
   headers:
     x-correlator:
       description: Correlation id for the different services
@@ -34,6 +39,12 @@ components:
       pattern: ^[a-zA-Z0-9-_:;.\/<>{}]{0,256}$
       maxLength: 256
       example: "b4333c46-49c0-4f62-80d7-f0ef930f1c46"
+    DateTime:
+      type: string
+      format: date-time
+      maxLength: 64
+      description: Timestamp. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+      example: "2018-04-05T17:31:00Z"
     TimePeriod:
       type: object
       description: A period of time defined by a start date and an optional end date

--- a/code/common/CAMARA_event_common.yaml
+++ b/code/common/CAMARA_event_common.yaml
@@ -1,0 +1,610 @@
+info:
+  title: CAMARA common event and subscription data types
+  description: |
+    Common data types for CAMARA event notification and subscription management.
+    This file contains Commonalities-owned schemas that are identical across all
+    CAMARA APIs supporting event notifications and/or explicit subscriptions.
+
+    API repositories place this file in `code/common/` alongside `CAMARA_common.yaml`
+    and reference schemas via `$ref: "../common/CAMARA_event_common.yaml#/components/schemas/<SchemaName>"`.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  version: wip
+  x-camara-commonalities: 0.7.0
+
+components:
+  schemas:
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Section 1: CloudEvents 1.0 envelope
+    #
+    # Pure CloudEvents 1.0 specification envelope. Knows nothing about CAMARA
+    # event types, data payloads, or discriminator mappings. Any CAMARA API
+    # that needs to send a notification starts here.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    CloudEvent:
+      type: object
+      description: |
+        CloudEvents 1.0 specification envelope.
+        This schema is the stable base for all CAMARA event notifications.
+        It imposes no constraints on `type` values or `data` structure —
+        those concerns belong to the API-specific and lifecycle group schemas.
+      required:
+        - id
+        - source
+        - specversion
+        - type
+        - time
+      properties:
+        id:
+          type: string
+          maxLength: 256
+          description: Identifier of this event, unique within the source context.
+        source:
+          $ref: "#/components/schemas/Source"
+        type:
+          type: string
+          maxLength: 512
+          description: |
+            Identifies the event type. CAMARA APIs use reverse-DNS notation:
+            `org.camaraproject.<api-name>.<event-version>.<event-name>`
+            The api-name segment makes each type globally unique across API groups.
+        specversion:
+          type: string
+          description: Version of the specification to which this event conforms (must be 1.0 if it conforms to cloudevents 1.0.2 version)
+          enum:
+            - "1.0"
+        datacontenttype:
+          type: string
+          description: 'media-type that describes the event payload encoding, must be "application/json" for CAMARA APIs'
+          enum:
+            - application/json
+        data:
+          type: object
+          description: Event details payload. Structure is defined by each concrete event schema.
+        time:
+          $ref: "CAMARA_common.yaml#/components/schemas/DateTime"
+
+    Source:
+      type: string
+      format: uri-reference
+      minLength: 1
+      maxLength: 2048
+      description: |
+        Identifies the context in which an event happened - be a non-empty `URI-reference` like:
+        - URI with a DNS authority:
+          * https://github.com/cloudevents
+          * mailto:cncf-wg-serverless@lists.cncf.io
+        - Universally-unique URN with a UUID:
+          * urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66
+        - Application-specific identifier:
+          * /cloudevents/spec/pull/123
+          * 1-555-123-4567
+      example: "https://notificationSendServer12.example.com"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Section 2: Subscription management
+    #
+    # Configuration and identification schemas used by the subscription
+    # management endpoints. These are Commonalities-owned and identical
+    # across all CAMARA APIs that support explicit subscriptions.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionId:
+      type: string
+      maxLength: 256
+      description: The unique identifier of the subscription in the scope of the subscription manager. When this information is contained within an event notification, it SHALL be referred to as `subscriptionId` as per the Commonalities Event Notification Model.
+      example: qs15-h556-rt89-1298
+
+    Config:
+      description: |
+        Implementation-specific configuration parameters needed by the subscription manager for acquiring events.
+        In CAMARA we have predefined attributes like `subscriptionExpireTime`, `subscriptionMaxEvents`, `initialEvent`
+        Specific event type attributes must be defined in `subscriptionDetail`.
+        Note: if a request is performed for several event types, all subscribed events will use same `config` parameters.
+      type: object
+      required:
+        - subscriptionDetail
+      properties:
+        subscriptionDetail:
+          $ref: "#/components/schemas/CreateSubscriptionDetail"
+        subscriptionExpireTime:
+          type: string
+          format: date-time
+          maxLength: 64
+          example: 2023-01-17T13:18:23.682Z
+          description: The subscription expiration time (in date-time format) requested by the API consumer. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Up to API project decision to keep it.
+        subscriptionMaxEvents:
+          type: integer
+          format: int32
+          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends. Up to API project decision to keep it.
+          minimum: 1
+          maximum: 1000000
+          example: 5
+        initialEvent:
+          type: boolean
+          description: |
+            Set to `true` by API consumer if consumer wants to get an event as soon as the subscription is created and current situation reflects event request.
+            Example: Consumer request Roaming event. If consumer sets initialEvent to true and device is in roaming situation, an event is triggered
+            Up to API project decision to keep it.
+
+    CreateSubscriptionDetail:
+      description: The detail of the requested event subscription.
+      type: object
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Section 3: Protocol support
+    #
+    # Protocol selection and protocol-specific delivery settings.
+    # These are Commonalities-owned and identical across all CAMARA APIs.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    Protocol:
+      type: string
+      enum: ["HTTP", "MQTT3", "MQTT5", "AMQP", "NATS", "KAFKA"]
+      description: Identifier of a delivery protocol. Only HTTP is allowed for now
+      example: "HTTP"
+
+    HTTPSettings:
+      type: object
+      description: HTTP protocol settings for event delivery.
+      properties:
+        headers:
+          type: object
+          description: |-
+            A set of key/value pairs that is copied into the HTTP request as custom headers.
+
+            NOTE: Use/Applicability of this concept has not been discussed in Commonalities. When required by an API project as an option to meet a UC/Requirement, please generate an issue for Commonalities discussion about it.
+          additionalProperties:
+            type: string
+            maxLength: 512
+        method:
+          type: string
+          description: The HTTP method to use for sending the message.
+          enum:
+            - POST
+
+    MQTTSettings:
+      type: object
+      properties:
+        topicName:
+          type: string
+          maxLength: 256
+          description: MQTT topic name
+        qos:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 2
+          description: Quality of Service level (0, 1, or 2)
+        retain:
+          type: boolean
+        expiry:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 2147483647
+          description: Message expiry interval in seconds
+        userProperties:
+          type: object
+      required:
+        - topicName
+
+    AMQPSettings:
+      type: object
+      properties:
+        address:
+          type: string
+          maxLength: 512
+        linkName:
+          type: string
+          maxLength: 256
+        senderSettlementMode:
+          type: string
+          enum: ["settled", "unsettled"]
+        linkProperties:
+          type: object
+          additionalProperties:
+            type: string
+            maxLength: 1024
+
+    ApacheKafkaSettings:
+      type: object
+      properties:
+        topicName:
+          type: string
+          maxLength: 249
+        partitionKeyExtractor:
+          type: string
+          maxLength: 512
+        clientId:
+          type: string
+          maxLength: 256
+        ackMode:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 2
+          description: Acknowledgment mode (0=no ack, 1=leader ack, 2=all replicas ack)
+      required:
+        - topicName
+
+    NATSSettings:
+      type: object
+      properties:
+        subject:
+          type: string
+          maxLength: 256
+          description: NATS subject
+      required:
+        - subject
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Section 4: Sink credentials
+    #
+    # Authentication and authorization information for event delivery.
+    # These are Commonalities-owned and identical across all CAMARA APIs.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SinkCredential:
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
+      type: object
+      properties:
+        credentialType:
+          type: string
+          enum:
+            - PLAIN
+            - ACCESSTOKEN
+            - PRIVATE_KEY_JWT
+          description: |
+            The type of the credential - MUST be set to ACCESSTOKEN or PRIVATE_KEY_JWT for now
+      discriminator:
+        propertyName: credentialType
+        mapping:
+          PLAIN: "#/components/schemas/PlainCredential"
+          ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
+          PRIVATE_KEY_JWT: "#/components/schemas/PrivateKeyJWTCredential"
+      required:
+        - credentialType
+
+    PlainCredential:
+      type: object
+      description: A plain credential as a combination of an identifier and a secret.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          required:
+            - identifier
+            - secret
+          properties:
+            identifier:
+              description: The identifier might be an account or username.
+              type: string
+              maxLength: 256
+            secret:
+              description: The secret might be a password or passphrase.
+              type: string
+              maxLength: 512
+
+    AccessTokenCredential:
+      type: object
+      description: An access token credential. This type of credential is meant to be used by API Consumers that have limited capabilities to handle authorization requests.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+        - type: object
+          properties:
+            accessToken:
+              description: REQUIRED. An access token is a token granting access to the target resource.
+              type: string
+              maxLength: 4096
+            accessTokenExpiresUtc:
+              type: string
+              format: date-time
+              maxLength: 64
+              description: |
+                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+                In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
+                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
+                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+              example: "2023-07-03T12:27:08.312Z"
+            accessTokenType:
+              description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
+              type: string
+              enum:
+                - bearer
+          required:
+            - accessToken
+            - accessTokenExpiresUtc
+            - accessTokenType
+
+    PrivateKeyJWTCredential:
+      type: object
+      description: Use PRIVATE_KEY_JWT to get an access token. The authorization server information needed for this type of sink credential (token endpoint, client ID, JWKS URL) is shared upfront between the client and the CAMARA entity. This type of credential is to be used by clients that have an authorization server.
+      allOf:
+        - $ref: "#/components/schemas/SinkCredential"
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # Section 5: Subscription lifecycle data
+    #
+    # Data payload schemas for subscription lifecycle events. These define the
+    # `data` content of subscription-started, subscription-updated, and
+    # subscription-ended events. The lifecycle event wrappers (which contain
+    # api-name placeholders in their event type strings) stay in API templates.
+    # ─────────────────────────────────────────────────────────────────────────
+
+    SubscriptionStarted:
+      description: Event detail structure for subscription started event
+      type: object
+      required:
+        - initiationReason
+        - subscriptionId
+      properties:
+        initiationReason:
+          $ref: "#/components/schemas/InitiationReason"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
+        initiationDescription:
+          type: string
+          maxLength: 512
+          description: Description of subscription initiation
+
+    InitiationReason:
+      type: string
+      description: |
+        - SUBSCRIPTION_CREATED - Subscription created by API Server
+      enum:
+        - SUBSCRIPTION_CREATED
+
+    SubscriptionUpdated:
+      description: Event detail structure for subscription updated event
+      type: object
+      required:
+        - updateReason
+        - subscriptionId
+      properties:
+        updateReason:
+          $ref: "#/components/schemas/UpdateReason"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
+        updateDescription:
+          type: string
+          maxLength: 512
+          description: Description of subscription update
+
+    UpdateReason:
+      type: string
+      description: |
+        - SUBSCRIPTION_ACTIVE - API server transitioned subscription status to `ACTIVE`
+        - SUBSCRIPTION_INACTIVE - API server transitioned subscription status to `INACTIVE`
+      enum:
+        - SUBSCRIPTION_ACTIVE
+        - SUBSCRIPTION_INACTIVE
+
+    SubscriptionEnded:
+      description: Event detail structure for subscription ended event
+      type: object
+      required:
+        - terminationReason
+        - subscriptionId
+      properties:
+        terminationReason:
+          $ref: "#/components/schemas/TerminationReason"
+        subscriptionId:
+          $ref: "#/components/schemas/SubscriptionId"
+        terminationDescription:
+          type: string
+          maxLength: 512
+          description: Description of subscription termination
+
+    TerminationReason:
+      type: string
+      description: |
+        - NETWORK_TERMINATED - API server stopped sending notification
+        - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
+        - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
+        - ACCESS_TOKEN_EXPIRED - Access Token sinkCredential (optionally set by the requester with credential type `ACCESSTOKEN`) expiration time has been reached
+        - SUBSCRIPTION_DELETED - Subscription was deleted by the requester
+      enum:
+        - MAX_EVENTS_REACHED
+        - NETWORK_TERMINATED
+        - SUBSCRIPTION_EXPIRED
+        - ACCESS_TOKEN_EXPIRED
+        - SUBSCRIPTION_DELETED
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Subscription-specific error responses
+  #
+  # These extend generic CAMARA error codes with subscription-specific codes.
+  # Commonalities-owned and identical across all APIs using explicit subscriptions.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  responses:
+    CreateSubscriptionBadRequest400:
+      description: Problem with the client request
+      headers:
+        x-correlator:
+          $ref: "CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
+                      - INVALID_PROTOCOL
+                      - INVALID_CREDENTIAL
+                      - INVALID_TOKEN
+                      - INVALID_SINK
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
+            GENERIC_400_INVALID_PROTOCOL:
+              description: Invalid protocol for events subscription management
+              value:
+                status: 400
+                code: INVALID_PROTOCOL
+                message: Only HTTP is supported
+            GENERIC_400_INVALID_CREDENTIAL:
+              description: Invalid sink credential type
+              value:
+                status: 400
+                code: INVALID_CREDENTIAL
+                message: Only Access token or Private key JWT are supported
+            GENERIC_400_INVALID_SINK:
+              description: Invalid sink value
+              value:
+                status: 400
+                code: INVALID_SINK
+                message: sink not valid for the specified protocol
+
+    SubscriptionIdRequired400:
+      description: Problem with the client request
+      headers:
+        x-correlator:
+          $ref: "CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 400
+                  code:
+                    enum:
+                      - INVALID_ARGUMENT
+          examples:
+            GENERIC_400_INVALID_ARGUMENT:
+              description: Invalid Argument. Generic Syntax Exception
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_SUBSCRIPTION_ID_REQUIRED:
+              description: subscription id is required
+              value:
+                status: 400
+                code: INVALID_ARGUMENT
+                message: "Expected property is missing: subscriptionId"
+
+    SubscriptionPermissionDenied403:
+      description: Client does not have sufficient permission
+      headers:
+        x-correlator:
+          $ref: "CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 403
+                  code:
+                    enum:
+                      - PERMISSION_DENIED
+                      - SUBSCRIPTION_MISMATCH
+          examples:
+            GENERIC_403_PERMISSION_DENIED:
+              description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
+              value:
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action.
+            GENERIC_403_SUBSCRIPTION_MISMATCH:
+              description: Inconsistent access token for requested subscription
+              value:
+                status: 403
+                code: "SUBSCRIPTION_MISMATCH"
+                message: "Inconsistent access token for requested events subscription"
+
+    CreateSubscriptionUnprocessableEntity422:
+      description: Unprocessable Entity
+      headers:
+        x-correlator:
+          $ref: "CAMARA_common.yaml#/components/headers/x-correlator"
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "CAMARA_common.yaml#/components/schemas/ErrorInfo"
+              - type: object
+                properties:
+                  status:
+                    enum:
+                      - 422
+                  code:
+                    enum:
+                      - SERVICE_NOT_APPLICABLE
+                      - MISSING_IDENTIFIER
+                      - UNSUPPORTED_IDENTIFIER
+                      - UNNECESSARY_IDENTIFIER
+                      - MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
+                      - MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED
+                      - PRIVATE_KEY_JWT_NOT_CONFIGURED
+          examples:
+            GENERIC_422_SERVICE_NOT_APPLICABLE:
+              description: Service not applicable for the provided identifier
+              value:
+                status: 422
+                code: SERVICE_NOT_APPLICABLE
+                message: The service is not available for the provided identifier.
+            GENERIC_422_MISSING_IDENTIFIER:
+              description: An identifier is not included in the request and the device or phone number identification cannot be derived from the 3-legged access token
+              value:
+                status: 422
+                code: MISSING_IDENTIFIER
+                message: The device cannot be identified.
+            GENERIC_422_UNSUPPORTED_IDENTIFIER:
+              description: None of the provided identifiers is supported by the implementation
+              value:
+                status: 422
+                code: UNSUPPORTED_IDENTIFIER
+                message: The identifier provided is not supported.
+            GENERIC_422_UNNECESSARY_IDENTIFIER:
+              description: An explicit identifier is provided when a device or phone number has already been identified from the access token
+              value:
+                status: 422
+                code: UNNECESSARY_IDENTIFIER
+                message: The device is already identified by the access token.
+            GENERIC_422_MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED:
+              description: Multi event types subscription is not supported
+              value:
+                status: 422
+                code: MULTIEVENT_SUBSCRIPTION_NOT_SUPPORTED
+                message: Multi event types subscription not managed
+            GENERIC_422_MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED:
+              description: Combination of multiple event types is temporarily not supported
+              value:
+                status: 422
+                code: MULTIEVENT_COMBINATION_TEMPORARILY_NOT_SUPPORTED
+                message: The requested combination of event types is temporarily not supported.
+            GENERIC_422_PRIVATE_KEY_JWT_NOT_CONFIGURED:
+              description: Private key JWT sink credential type is used but no configuration was pre-shared
+              value:
+                status: 422
+                code: PRIVATE_KEY_JWT_NOT_CONFIGURED
+                message: No JWK Set configured for PRIVATE_KEY_JWT authentication.


### PR DESCRIPTION
#### What type of PR is this?

* correction

#### What this PR does / why we need it:

Aligns both API definitions with the CAMARA API Design Guide and syncs common files with the artifacts restructuring in [Commonalities#606](https://github.com/camaraproject/Commonalities/pull/606).

**release-test.yaml** (standalone, no external `$ref`):
- Add `components` section: `securitySchemes` (openId), `x-correlator` header/parameter, `ErrorInfo`, `ServiceStatus` schemas
- Add mandatory 401/403 error responses with examples
- Fix `x-camara-commonalities` (0.6 → 0.7.0), `externalDocs` URL, `apiRoot` description

**sample-service.yaml** (uses `$ref` to common files):
- Sync from Commonalities#606: title without "API", `externalDocs`, `apiRoot` description, pagination on list response, `ResourceId` maxLength for UUID

**CAMARA_common.yaml**:
- Sync from Commonalities#606: `DateTime` schema, `openId` description, components-only format

**CAMARA_event_common.yaml** (new):
- Add from Commonalities#606 for bundling and validation testing

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Special notes for reviewers:

Both APIs pass Spectral lint with zero errors and zero warnings.
Common files synced from Commonalities#606 — may need minor updates as that PR progresses through review.

#### Changelog input

```
 release-note
fix: align API definitions with Design Guide, add CAMARA_event_common.yaml
```