### PR TITLE
fix: comment out non-HTTP protocol support (not yet used in CAMARA)

### DIFF
--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -537,6 +537,64 @@ components:
     # ─────────────────────────────────────────────────────────────────────────
     # Protocol-specific subscription schemas
     # Protocol settings are referenced from CAMARA_event_common.yaml.
+    #
+    # Future protocol support (not yet used in CAMARA):
+    # MQTTSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
+    # MQTTSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
+    # AMQPSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
+    # AMQPSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
+    # ApacheKafkaSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
+    # ApacheKafkaSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
+    # NATSSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
+    # NATSSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
     # ─────────────────────────────────────────────────────────────────────────
 
     HTTPSubscriptionRequest:
@@ -556,68 +614,3 @@ components:
           properties:
             protocolSettings:
               $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"
-
-    # Future protocol support (not yet used in CAMARA):
-    # MQTTSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
-
-    # MQTTSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
-
-    # AMQPSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
-
-    # AMQPSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
-
-    # ApacheKafkaSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
-
-    # ApacheKafkaSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
-
-    # NATSSubscriptionRequest:
-    #   allOf:
-    #     - $ref: "#/components/schemas/SubscriptionRequest"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
-
-    # NATSSubscriptionResponse:
-    #   allOf:
-    #     - $ref: "#/components/schemas/Subscription"
-    #     - type: object
-    #       properties:
-    #         protocolSettings:
-    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"

--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -284,11 +284,12 @@ components:
         propertyName: protocol
         mapping:
           HTTP: "#/components/schemas/HTTPSubscriptionRequest"
-          MQTT3: "#/components/schemas/MQTTSubscriptionRequest"
-          MQTT5: "#/components/schemas/MQTTSubscriptionRequest"
-          AMQP: "#/components/schemas/AMQPSubscriptionRequest"
-          NATS: "#/components/schemas/NATSSubscriptionRequest"
-          KAFKA: "#/components/schemas/ApacheKafkaSubscriptionRequest"
+          # Future protocol support (not yet used in CAMARA):
+          # MQTT3: "#/components/schemas/MQTTSubscriptionRequest"
+          # MQTT5: "#/components/schemas/MQTTSubscriptionRequest"
+          # AMQP: "#/components/schemas/AMQPSubscriptionRequest"
+          # NATS: "#/components/schemas/NATSSubscriptionRequest"
+          # KAFKA: "#/components/schemas/ApacheKafkaSubscriptionRequest"
 
     Subscription:
       description: Represents a event-type subscription.
@@ -347,11 +348,12 @@ components:
         propertyName: protocol
         mapping:
           HTTP: "#/components/schemas/HTTPSubscriptionResponse"
-          MQTT3: "#/components/schemas/MQTTSubscriptionResponse"
-          MQTT5: "#/components/schemas/MQTTSubscriptionResponse"
-          AMQP: "#/components/schemas/AMQPSubscriptionResponse"
-          NATS: "#/components/schemas/NATSSubscriptionResponse"
-          KAFKA: "#/components/schemas/ApacheKafkaSubscriptionResponse"
+          # Future protocol support (not yet used in CAMARA):
+          # MQTT3: "#/components/schemas/MQTTSubscriptionResponse"
+          # MQTT5: "#/components/schemas/MQTTSubscriptionResponse"
+          # AMQP: "#/components/schemas/AMQPSubscriptionResponse"
+          # NATS: "#/components/schemas/NATSSubscriptionResponse"
+          # KAFKA: "#/components/schemas/ApacheKafkaSubscriptionResponse"
 
     SubscriptionAsync:
       description: Response for a event-type subscription request managed asynchronously (Creation or Deletion)
@@ -555,66 +557,67 @@ components:
             protocolSettings:
               $ref: "../common/CAMARA_event_common.yaml#/components/schemas/HTTPSettings"
 
-    MQTTSubscriptionRequest:
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionRequest"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
+    # Future protocol support (not yet used in CAMARA):
+    # MQTTSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
 
-    MQTTSubscriptionResponse:
-      allOf:
-        - $ref: "#/components/schemas/Subscription"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
+    # MQTTSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/MQTTSettings"
 
-    AMQPSubscriptionRequest:
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionRequest"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
+    # AMQPSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
 
-    AMQPSubscriptionResponse:
-      allOf:
-        - $ref: "#/components/schemas/Subscription"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
+    # AMQPSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/AMQPSettings"
 
-    ApacheKafkaSubscriptionRequest:
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionRequest"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
+    # ApacheKafkaSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
 
-    ApacheKafkaSubscriptionResponse:
-      allOf:
-        - $ref: "#/components/schemas/Subscription"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
+    # ApacheKafkaSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/ApacheKafkaSettings"
 
-    NATSSubscriptionRequest:
-      allOf:
-        - $ref: "#/components/schemas/SubscriptionRequest"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
+    # NATSSubscriptionRequest:
+    #   allOf:
+    #     - $ref: "#/components/schemas/SubscriptionRequest"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
 
-    NATSSubscriptionResponse:
-      allOf:
-        - $ref: "#/components/schemas/Subscription"
-        - type: object
-          properties:
-            protocolSettings:
-              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"
+    # NATSSubscriptionResponse:
+    #   allOf:
+    #     - $ref: "#/components/schemas/Subscription"
+    #     - type: object
+    #       properties:
+    #         protocolSettings:
+    #           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/NATSSettings"

--- a/code/common/CAMARA_event_common.yaml
+++ b/code/common/CAMARA_event_common.yaml
@@ -143,7 +143,14 @@ components:
 
     Protocol:
       type: string
-      enum: ["HTTP", "MQTT3", "MQTT5", "AMQP", "NATS", "KAFKA"]
+      enum:
+        - HTTP
+        # Future protocol support (not yet used in CAMARA):
+        # - MQTT3
+        # - MQTT5
+        # - AMQP
+        # - NATS
+        # - KAFKA
       description: Identifier of a delivery protocol. Only HTTP is allowed for now
       example: "HTTP"
 
@@ -166,80 +173,81 @@ components:
           enum:
             - POST
 
-    MQTTSettings:
-      type: object
-      properties:
-        topicName:
-          type: string
-          maxLength: 256
-          description: MQTT topic name
-        qos:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 2
-          description: Quality of Service level (0, 1, or 2)
-        retain:
-          type: boolean
-        expiry:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 2147483647
-          description: Message expiry interval in seconds
-        userProperties:
-          type: object
-      required:
-        - topicName
+    # Future protocol support (not yet used in CAMARA):
+    # MQTTSettings:
+    #   type: object
+    #   properties:
+    #     topicName:
+    #       type: string
+    #       maxLength: 256
+    #       description: MQTT topic name
+    #     qos:
+    #       type: integer
+    #       format: int32
+    #       minimum: 0
+    #       maximum: 2
+    #       description: Quality of Service level (0, 1, or 2)
+    #     retain:
+    #       type: boolean
+    #     expiry:
+    #       type: integer
+    #       format: int32
+    #       minimum: 0
+    #       maximum: 2147483647
+    #       description: Message expiry interval in seconds
+    #     userProperties:
+    #       type: object
+    #   required:
+    #     - topicName
 
-    AMQPSettings:
-      type: object
-      properties:
-        address:
-          type: string
-          maxLength: 512
-        linkName:
-          type: string
-          maxLength: 256
-        senderSettlementMode:
-          type: string
-          enum: ["settled", "unsettled"]
-        linkProperties:
-          type: object
-          additionalProperties:
-            type: string
-            maxLength: 1024
+    # AMQPSettings:
+    #   type: object
+    #   properties:
+    #     address:
+    #       type: string
+    #       maxLength: 512
+    #     linkName:
+    #       type: string
+    #       maxLength: 256
+    #     senderSettlementMode:
+    #       type: string
+    #       enum: ["settled", "unsettled"]
+    #     linkProperties:
+    #       type: object
+    #       additionalProperties:
+    #         type: string
+    #         maxLength: 1024
 
-    ApacheKafkaSettings:
-      type: object
-      properties:
-        topicName:
-          type: string
-          maxLength: 249
-        partitionKeyExtractor:
-          type: string
-          maxLength: 512
-        clientId:
-          type: string
-          maxLength: 256
-        ackMode:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 2
-          description: Acknowledgment mode (0=no ack, 1=leader ack, 2=all replicas ack)
-      required:
-        - topicName
+    # ApacheKafkaSettings:
+    #   type: object
+    #   properties:
+    #     topicName:
+    #       type: string
+    #       maxLength: 249
+    #     partitionKeyExtractor:
+    #       type: string
+    #       maxLength: 512
+    #     clientId:
+    #       type: string
+    #       maxLength: 256
+    #     ackMode:
+    #       type: integer
+    #       format: int32
+    #       minimum: 0
+    #       maximum: 2
+    #       description: Acknowledgment mode (0=no ack, 1=leader ack, 2=all replicas ack)
+    #   required:
+    #     - topicName
 
-    NATSSettings:
-      type: object
-      properties:
-        subject:
-          type: string
-          maxLength: 256
-          description: NATS subject
-      required:
-        - subject
+    # NATSSettings:
+    #   type: object
+    #   properties:
+    #     subject:
+    #       type: string
+    #       maxLength: 256
+    #       description: NATS subject
+    #   required:
+    #     - subject
 
     # ─────────────────────────────────────────────────────────────────────────
     # Section 4: Sink credentials


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature

#### What this PR does / why we need it:

Comments out non-HTTP protocol references (MQTT3, MQTT5, AMQP, NATS, KAFKA) in both `sample-service-subscriptions.yaml` and `CAMARA_event_common.yaml`, as proposed by the Commonalities WG for Commonalities#606.

Comments stay in the source files signaling future extensibility. After bundling, only HTTP-related schemas appear in the output.

Changes:
- **Protocol enum**: converted from inline array to block sequence, only `HTTP` active
- **Discriminator mappings**: only HTTP mapping active in both SubscriptionRequest and Subscription
- **Protocol-specific schemas**: 8 non-HTTP request/response schemas commented out
- **Settings schemas**: MQTTSettings, AMQPSettings, ApacheKafkaSettings, NATSSettings commented out

#### Which issue(s) this PR fixes:

Testing ground for [Commonalities#606](https://github.com/camaraproject/Commonalities/pull/606) protocol commenting proposal.

#### Special notes for reviewers:

Validated locally:
- YAML syntax: valid
- `redocly bundle`: succeeds, bundled output contains zero non-HTTP references
- `spectral lint` (r4 ruleset): 0 errors, 14 pre-existing warnings (no new warnings from this change)

#### Changelog input

```
 release-note
N/A (test repository)
```

#### Additional documentation 

```
docs
N/A
```