### PR TITLE
fix: align common files and templates with Commonalities #606

### DIFF
--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -13,7 +13,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.8.0
+  x-camara-commonalities: 0.7.0
 
 externalDocs:
   description: Product documentation at CAMARA
@@ -220,12 +220,7 @@ components:
     openId:
       $ref: "../common/CAMARA_common.yaml#/components/securitySchemes/openId"
     notificationsBearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
-      description: |
-        Bearer token for notification delivery. Token format is determined
-        by `sinkCredential.credentialType` in the subscription request.
+      $ref: "../common/CAMARA_event_common.yaml#/components/securitySchemes/notificationsBearerAuth"
 
   parameters:
     SubscriptionId:
@@ -310,8 +305,6 @@ components:
           pattern: ^https:\/\/.+$
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
-        sinkCredential:
-          $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible to be delivered by this subscription.
@@ -376,8 +369,8 @@ components:
         globally unique, so two different API groups can independently define
         identically-named event types without any collision risk.
       enum:
-        - org.camaraproject.api-name.v0.event-type1
-        - org.camaraproject.api-name.v0.event-type2
+        - org.camaraproject.sample-service-subscriptions.v0.event-type1
+        - org.camaraproject.sample-service-subscriptions.v0.event-type2
 
     # ─────────────────────────────────────────────────────────────────────────
     # Subscription lifecycle event group (Commonalities-owned structure,
@@ -406,9 +399,9 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          org.camaraproject.api-name.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
-          org.camaraproject.api-name.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
-          org.camaraproject.api-name.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
+          org.camaraproject.sample-service-subscriptions.v0.subscription-started: "#/components/schemas/EventSubscriptionStarted"
+          org.camaraproject.sample-service-subscriptions.v0.subscription-updated: "#/components/schemas/EventSubscriptionUpdated"
+          org.camaraproject.sample-service-subscriptions.v0.subscription-ended: "#/components/schemas/EventSubscriptionEnded"
 
     SubscriptionLifecycleEventType:
       type: string
@@ -419,9 +412,9 @@ components:
         Kept as a separate named schema so the set of valid lifecycle type
         strings can be referenced independently from the discriminated schema.
       enum:
-        - org.camaraproject.api-name.v0.subscription-started
-        - org.camaraproject.api-name.v0.subscription-updated
-        - org.camaraproject.api-name.v0.subscription-ended
+        - org.camaraproject.sample-service-subscriptions.v0.subscription-started
+        - org.camaraproject.sample-service-subscriptions.v0.subscription-updated
+        - org.camaraproject.sample-service-subscriptions.v0.subscription-ended
 
     # ─────────────────────────────────────────────────────────────────────────
     # API-specific notification event group
@@ -449,8 +442,8 @@ components:
       discriminator:
         propertyName: "type"
         mapping:
-          org.camaraproject.api-name.v0.event-type1: "#/components/schemas/EventApiSpecific1"
-          org.camaraproject.api-name.v0.event-type2: "#/components/schemas/EventApiSpecific2"
+          org.camaraproject.sample-service-subscriptions.v0.event-type1: "#/components/schemas/EventApiSpecific1"
+          org.camaraproject.sample-service-subscriptions.v0.event-type2: "#/components/schemas/EventApiSpecific2"
 
     # ─────────────────────────────────────────────────────────────────────────
     # Callback union (API project-owned)

--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -96,6 +96,8 @@ paths:
                 maxItems: 1000
                 items:
                   $ref: "#/components/schemas/Resource"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -122,6 +124,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Resource"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":
@@ -146,6 +150,8 @@ paths:
           headers:
             x-correlator:
               $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+        "400":
+          $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic401"
         "403":

--- a/code/common/CAMARA_common.yaml
+++ b/code/common/CAMARA_common.yaml
@@ -47,18 +47,12 @@ components:
       example: "2018-04-05T17:31:00Z"
     TimePeriod:
       type: object
-      description: A period of time defined by a start date and an optional end date
+      description: A period of time defined by a start date and an optional end date. If endDate is not included, then the period has no ending date.
       properties:
         startDate:
-          type: string
-          format: date-time
-          maxLength: 64
-          description: An instant of time, starting of the TimePeriod. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+          $ref: "#/components/schemas/DateTime"
         endDate:
-          type: string
-          format: date-time
-          maxLength: 64
-          description: An instant of time, ending of the TimePeriod. If not included, then the period has no ending date. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+          $ref: "#/components/schemas/DateTime"
       required:
         - startDate
     ErrorInfo:

--- a/code/common/CAMARA_event_common.yaml
+++ b/code/common/CAMARA_event_common.yaml
@@ -14,6 +14,15 @@ info:
   x-camara-commonalities: 0.7.0
 
 components:
+  securitySchemes:
+    notificationsBearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: "{$request.body#/sinkCredential.credentialType}"
+      description: |
+        Bearer token for notification delivery. Token format is determined
+        by `sinkCredential.credentialType` in the subscription request.
+
   schemas:
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -263,7 +272,7 @@ components:
         credentialType:
           type: string
           enum:
-            - PLAIN
+            # - PLAIN  # not used in CAMARA
             - ACCESSTOKEN
             - PRIVATE_KEY_JWT
           description: |
@@ -271,30 +280,30 @@ components:
       discriminator:
         propertyName: credentialType
         mapping:
-          PLAIN: "#/components/schemas/PlainCredential"
+          # PLAIN: "#/components/schemas/PlainCredential"  # not used in CAMARA
           ACCESSTOKEN: "#/components/schemas/AccessTokenCredential"
           PRIVATE_KEY_JWT: "#/components/schemas/PrivateKeyJWTCredential"
       required:
         - credentialType
 
-    PlainCredential:
-      type: object
-      description: A plain credential as a combination of an identifier and a secret.
-      allOf:
-        - $ref: "#/components/schemas/SinkCredential"
-        - type: object
-          required:
-            - identifier
-            - secret
-          properties:
-            identifier:
-              description: The identifier might be an account or username.
-              type: string
-              maxLength: 256
-            secret:
-              description: The secret might be a password or passphrase.
-              type: string
-              maxLength: 512
+    # PlainCredential:  # not used in CAMARA
+    #   type: object
+    #   description: A plain credential as a combination of an identifier and a secret.
+    #   allOf:
+    #     - $ref: "#/components/schemas/SinkCredential"
+    #     - type: object
+    #       required:
+    #         - identifier
+    #         - secret
+    #       properties:
+    #         identifier:
+    #           description: The identifier might be an account or username.
+    #           type: string
+    #           maxLength: 256
+    #         secret:
+    #           description: The secret might be a password or passphrase.
+    #           type: string
+    #           maxLength: 512
 
     AccessTokenCredential:
       type: object


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Aligns ReleaseTest common files and API templates with the latest state of [Commonalities PR #606](https://github.com/camaraproject/Commonalities/pull/606) (artifacts restructuring) and fixes all validation errors and actionable warnings reported by the [validation framework run](https://github.com/camaraproject/ReleaseTest/actions/runs/24084561328).

**Common files synced from #606:**
- `CAMARA_common.yaml`: TimePeriod properties use `$ref` to DateTime schema
- `CAMARA_event_common.yaml`: add `notificationsBearerAuth` securityScheme, comment out PLAIN credential (not used in CAMARA)

**Validation errors fixed (6 → 0):**
- P-016: remove `sinkCredential` from Subscription response schema (must not appear in responses per Design Guide)
- P-015: replace `api-name` placeholders with `sample-service-subscriptions` in event type strings (matching filename convention used by all CAMARA subscription APIs, e.g. `device-roaming-status-subscriptions`)

**Validation warnings fixed (4 → 1):**
- S-318: add Generic400 error responses to GET/DELETE operations in `sample-service.yaml` (OWASP define-error-validation)
- Remaining: GET /status in `release-test.yaml` skipped (no input params, uses inline schemas)

**Additional alignment:**
- `notificationsBearerAuth` in subscription template now uses `$ref` to `CAMARA_event_common.yaml`
- `x-camara-commonalities` version corrected from 0.8.0 to 0.7.0

#### Which issue(s) this PR fixes:

n/a — maintenance alignment

#### Special notes for reviewers:

The corresponding changes for `sample-service.yaml` (400 responses) and `sample-service-subscriptions.yaml` (api-name replacement) are also prepared as commits on Commonalities PR #606.

#### Changelog input

```
release-note
n/a — test repository maintenance
```

#### Additional documentation

```
docs
n/a
```