### PR TITLE
chore: reset release plan to r1.1 (target_release_type: none)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -8,19 +8,19 @@
 repository:
   # How this repository participates in CAMARA releases
   # Options: independent (default) | meta-release
-  release_track: meta-release
+  release_track: independent
 
   # Uncomment and set when planning a meta-release participation:
-  meta_release: Sync26
+  # meta_release: Sync26
 
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.4
+  target_release_tag: r1.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: none
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -33,23 +33,18 @@ dependencies:
 # - api_name: kebab-case identifier (used as filename in code/API_definitions/)
 # - target_api_status: draft | alpha | rc | public (draft allows no file yet)
 apis:
-  - api_name: release-test
-    target_api_version: 1.0.0
-    target_api_status: rc
-    main_contacts:
-      - hdamker-bot
   - api_name: sample-service
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker-bot
   - api_name: sample-service-subscriptions
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker-bot
   - api_name: sample-implicit-events
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker-bot


### PR DESCRIPTION
## What type of PR is this?

Cleanup / test repo reset.

## What this PR does

Resets the release plan for a fresh test cycle:
- Removes `release-test` API entry
- Switches from `meta-release` to `independent` track
- Sets `target_release_tag: r1.1` with 3 sample APIs at `alpha` status
- Sets `target_release_type: none` to allow clean closure of the existing release issue (#60) before starting the new cycle

A follow-up PR will remove stale files (release-test.yaml, feature file, CHANGELOG) and a third PR will set `target_release_type` to `pre-release-alpha`.

## Related issues

Prepares for clean closure of #60.