### PR TITLE
chore: activate r1.1 alpha release cycle

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle


### PR DESCRIPTION
## What type of PR is this?

Configuration change.

## What this PR does

Sets `target_release_type: pre-release-alpha` to start a fresh r1.1 release cycle with the three sample APIs.

On merge, the RA workflow should create a new Release Issue for r1.1.

## Related issues

Final step of test repo reset (follows #72, #73).