### PR TITLE
fix: sync sample API templates with Commonalities #606

### DIFF
--- a/code/API_definitions/sample-implicit-events.yaml
+++ b/code/API_definitions/sample-implicit-events.yaml
@@ -36,8 +36,7 @@ info:
 
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/apiRepository
-  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
+  url: https://github.com/camaraproject/ReleaseTest
 servers:
   - url: "{apiRoot}/sample-implicit-events/vwip"
     variables:

--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -19,8 +19,7 @@ info:
 
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/apiRepository
-  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
+  url: https://github.com/camaraproject/ReleaseTest
 servers:
   - url: "{apiRoot}/sample-service-subscriptions/vwip"
     variables:

--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -1,3 +1,5 @@
+# NOTE: This is a template. Replace all occurrences of "sample-service-subscriptions"
+# (and its Title Case variant) with the actual API name in the appropriate casing.
 openapi: 3.0.3
 info:
   title: Sample Service Subscription Template
@@ -7,7 +9,7 @@ info:
 
     Note on event name convention: the event type name MUST follow: ``org.camaraproject.<api-name>.<event-version>.<event-name>``
 
-    Note on ``security`` - ``openId`` scope: The value in this yaml `api-name:event-type1:grant-level` must be replaced accordingly to the format defined in the guideline document.
+    Note on ``security`` - ``openId`` scope: The scope values must be replaced accordingly to the format defined in the guideline document.
 
   license:
     name: Apache 2.0
@@ -17,7 +19,8 @@ info:
 
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/ReleaseTest
+  url: https://github.com/camaraproject/apiRepository
+  # {apiRepository} MUST be replaced by the CAMARA Subproject Repository name where the API design based on this template is hosted.
 servers:
   - url: "{apiRoot}/sample-service-subscriptions/vwip"
     variables:
@@ -25,23 +28,23 @@ servers:
         default: http://localhost:9091
         description: API root, defined by the service provider, e.g. `api.example.com` or `api.example.com/somepath`
 tags:
-  - name: <apiName> Subscription
+  - name: Sample Service Subscription
     description: Operations to manage event subscriptions on event-type event
 
 paths:
   /subscriptions:
     post:
       tags:
-        - <apiName> Subscription
-      summary: "Create a apiName event subscription"
-      description: Create a apiName event subscription
-      operationId: createApiNameSubscription
+        - Sample Service Subscription
+      summary: "Create a sample service event subscription"
+      description: Create a sample service event subscription
+      operationId: createSampleServiceSubscription
       parameters:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       security:
         - openId:
-            - api-name:event-type1:grant-level
-            - api-name:event-type2:grant-level
+            - sample-service-subscriptions:event-type1:grant-level
+            - sample-service-subscriptions:event-type2:grant-level
       requestBody:
         content:
           application/json:
@@ -55,7 +58,7 @@ paths:
               summary: "notifications callback"
               description: |
                 Important: this endpoint is to be implemented by the API consumer.
-                The apiName server will call this endpoint whenever a apiName event occurs.
+                The sample service server will call this endpoint whenever a sample service event occurs.
                 `operationId` value will have to be replaced accordingly with WG API specific semantic
               operationId: postNotification
               parameters:
@@ -119,15 +122,15 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
     get:
       tags:
-        - <apiName> Subscription
-      summary: "Retrieve a list of apiName event subscription"
-      description: Retrieve a list of apiName event subscription(s)
-      operationId: retrieveApiNameSubscriptionList
+        - Sample Service Subscription
+      summary: "Retrieve a list of sample service event subscriptions"
+      description: Retrieve a list of sample service event subscriptions
+      operationId: retrieveSampleServiceSubscriptionList
       parameters:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       security:
         - openId:
-            - api-name:read
+            - sample-service-subscriptions:read
       responses:
         "200":
           description: List of event subscription details
@@ -151,13 +154,13 @@ paths:
   /subscriptions/{subscriptionId}:
     get:
       tags:
-        - <apiName> Subscription
-      summary: "Retrieve a apiName event subscription"
-      description: retrieve apiName subscription information for a given subscription.
-      operationId: retrieveApiNameSubscription
+        - Sample Service Subscription
+      summary: "Retrieve a sample service event subscription"
+      description: Retrieve sample service subscription information for a given subscription.
+      operationId: retrieveSampleServiceSubscription
       security:
         - openId:
-            - api-name:read
+            - sample-service-subscriptions:read
       parameters:
         - $ref: "#/components/parameters/SubscriptionId"
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
@@ -181,19 +184,19 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic404"
     delete:
       tags:
-        - <apiName> Subscription
-      summary: "Delete a apiName event subscription"
-      operationId: deleteApiNameSubscription
-      description: delete a given apiName subscription.
+        - Sample Service Subscription
+      summary: "Delete a sample service event subscription"
+      operationId: deleteSampleServiceSubscription
+      description: Delete a given sample service subscription.
       security:
         - openId:
-            - api-name:delete
+            - sample-service-subscriptions:delete
       parameters:
         - $ref: "#/components/parameters/SubscriptionId"
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
       responses:
         "204":
-          description: apiName subscription deleted
+          description: Sample service subscription deleted
           headers:
             x-correlator:
               $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
@@ -237,7 +240,7 @@ components:
     # Subscription management (API-specific due to ApiEventType reference)
     #
     # SubscriptionRequest and Subscription reference ApiEventType in their
-    # `types` field, which contains api-name placeholders. Protocol-specific
+    # `types` field, which contains sample-service placeholders. Protocol-specific
     # request/response schemas extend these via allOf.
     # ─────────────────────────────────────────────────────────────────────────
 
@@ -358,7 +361,7 @@ components:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
 
     # ─────────────────────────────────────────────────────────────────────────
-    # API-specific event type enum (contains api-name placeholders)
+    # API-specific event type enum (contains sample-service placeholders)
     # ─────────────────────────────────────────────────────────────────────────
 
     ApiEventType:
@@ -374,14 +377,14 @@ components:
 
     # ─────────────────────────────────────────────────────────────────────────
     # Subscription lifecycle event group (Commonalities-owned structure,
-    # but event type strings contain api-name placeholders)
+    # but event type strings contain sample-service placeholders)
     #
     # Common to every CAMARA API that supports subscriptions.
     # Extends CloudEvent via allOf, constrains `type` to lifecycle values,
     # and owns the lifecycle discriminator mapping.
     #
     # API projects reference this group via NotificationEvent but only update
-    # the api-name prefix in the event type strings.
+    # the sample-service prefix in the event type strings.
     # ─────────────────────────────────────────────────────────────────────────
 
     SubscriptionLifecycleEvent:

--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -20,8 +20,7 @@ info:
   x-camara-commonalities: 0.7.0
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/{apiRepository}
-  # {apiRepository} MUST be replaced by the CAMARA API Repository name where the API specification is hosted.
+  url: https://github.com/camaraproject/ReleaseTest
 servers:
   - url: "{apiRoot}/sample-service/vwip"
     variables:

--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -20,7 +20,8 @@ info:
   x-camara-commonalities: 0.7.0
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/ReleaseTest
+  url: https://github.com/camaraproject/{apiRepository}
+  # {apiRepository} MUST be replaced by the CAMARA API Repository name where the API specification is hosted.
 servers:
   - url: "{apiRoot}/sample-service/vwip"
     variables:


### PR DESCRIPTION
## What type of PR is this?

Fix.

## What this PR does

Syncs sample-service.yaml and sample-service-subscriptions.yaml with the current Commonalities template source (PR #606 branch). Key changes:

- **sample-service-subscriptions.yaml**: replaces unreplaced `<apiName>` placeholders with proper `Sample Service` names (fixes S-021 tag name validation warning), updates operationIds and security scopes
- **sample-service.yaml**: restores template externalDocs URL

sample-implicit-events.yaml was already identical (copied from Commonalities in PR #71).

## Related issues

Fixes S-021 validation warning found during r1.1 snapshot review.