### PR TITLE
fix(ci): block RA bot by login, not Bot class

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -68,7 +68,7 @@ permissions:
 jobs:
   release-automation:
     # Skip if:
-    # - issue_comment from a Bot (release automation bot comments, not human commands)
+    # - issue_comment from the RA bot itself (its own replies, to prevent self-triggering)
     # - issue_comment but not a release command or not on a release issue
     # - issues event but not a release issue
     # - pull_request but not merged or not to a snapshot branch
@@ -76,7 +76,7 @@ jobs:
       (github.event_name == 'push') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' &&
-       github.event.comment.user.type != 'Bot' &&
+       github.event.comment.user.login != 'camara-release-automation[bot]' &&
        contains(github.event.issue.labels.*.name, 'release-issue') &&
        (startsWith(github.event.comment.body, '/create-snapshot') ||
         startsWith(github.event.comment.body, '/discard-snapshot') ||


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

The `release-automation` job's `if:` filter blocks all bot-authored comments (`comment.user.type != 'Bot'`). That also blocks non-RA bots that legitimately fire slash commands from CI — specifically the new Release Automation Regression canary in camaraproject/tooling ([tooling#214](https://github.com/camaraproject/tooling/pull/214)), which posts `/create-snapshot` via the `camara-validation` App.

Narrow the filter to the RA bot identity. Self-triggering is still prevented; other bot identities pass through to the slash-command gate.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Once validated here, the same narrowing lands in the `release-automation-caller.yml` template in tooling and rolls out via the reconciliation campaign.

#### Changelog input

```
 release-note
 none (CI filter fix)
```

#### Additional documentation

This section can be blank.

```
docs
```