### PR TITLE
docs(readme): document regression-canary use + required post-test state

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 # ReleaseTest
 
 > [!CAUTION]
-> This repository is exclusively used for testing the [CAMARA release automation](https://github.com/camaraproject/tooling/tree/release-automation/release_automation) workflow ([tooling#72](https://github.com/camaraproject/tooling/issues/72)). It is not an actual API repository. Issues, releases, and branches may be created and deleted at any time without notice.
+> This repository is used for testing the [CAMARA release management tooling](https://github.com/camaraproject/tooling) — both for manual end-to-end tests and as the target for automated regression canaries. It is not an actual API repository. After any manual tests, leave the repository in a `planned` state with an open Release Issue so the next canary run passes its pre-check.
 
 ## Scope
 
-Test repository for end-to-end validation of the automated release workflow. Contains a minimal API stub to exercise the full release lifecycle:
+Test repository for end-to-end validation of the automated release workflow, and target for the Validation Regression and Release Automation Regression canaries running from [camaraproject/tooling](https://github.com/camaraproject/tooling). Carries the Commonalities sample API templates under `code/API_definitions/` as test fixtures, which exercise the full release lifecycle:
 
 * Sync Release Issue from `release-plan.yaml`
 * Create snapshot and release-review branch
@@ -40,6 +40,17 @@ Test repository for end-to-end validation of the automated release workflow. Con
 
 _The above section is automatically synchronized by CAMARA project-administration._
 <!-- CAMARA:RELEASE-INFO:END -->
+
+## Regression canary target
+
+This repository is the target for the **Validation Regression** and **Release Automation Regression** canaries in [camaraproject/tooling](https://github.com/camaraproject/tooling), which fire on every push to the `validation-framework` branch.
+
+State to preserve:
+
+* **`regression/r4.1-*` branches are permanent** — each carries a `.regression/regression-expected.yaml` fixture. Do not rename or delete.
+* **After any manual tests, leave the repository in a valid `planned` state with an open Release Issue** — otherwise the next RA canary run fails its pre-check.
+
+Side-effect: each `/discard-snapshot` (canary or manual) leaves a `release-review/*-preserved` branch behind. These are harmless historical artifacts and are not swept automatically.
 
 ## Contributing
 


### PR DESCRIPTION
#### What type of PR is this?

documentation

#### What this PR does / why we need it:

Three small README updates to reflect the repository's expanded role since the Release Automation Regression canary ([camaraproject/tooling#214](https://github.com/camaraproject/tooling/pull/214) + follow-ups) and the Validation Regression canary went live:

- **CAUTION** block: adds that the repo is also the target for automated regression canaries, and that after any manual tests the repo must be left in a `planned` state with an open Release Issue.
- **Scope**: calls out the canary-target role and corrects "minimal API stub" → "Commonalities sample API templates under `code/API_definitions/` as test fixtures".
- **New "Regression canary target" section**: which branches are permanent (`regression/r4.1-*` + their fixtures), the post-manual-test requirement, and the `release-review/*-preserved` accumulation side-effect.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Documentation only — no workflow or code changes.

#### Changelog input

```
 release-note
 none (documentation only)
```

#### Additional documentation

This section can be blank.

```
docs
```