### PR TITLE
[VF E2E Scenario 1] baseline — API YAML edit only

### DIFF
--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -30,6 +30,8 @@ servers:
 tags:
   - name: Resources
     description: Operations on sample resources
+  - name: E2ETest
+    description: Placeholder tag for VF E2E Scenario 1 baseline (will be reverted)
 security:
   - openId:
       - sample-service:resource:read


### PR DESCRIPTION
Throwaway PR for Validation Framework E2E — tag-move gate for `@v1-rc`.

**Scenario 1 (baseline)**: Change one API YAML only; no `release-plan.yaml` touch.

Expected: P-009/P-022/P-023 skipped by applicability. Spectral, gherkin, Python rules run normally. `release_plan_check_only` empty/false.

Will be closed without merging and the branch deleted.