### PR TITLE
[VF E2E Scenario 2] release-plan.yaml only (non-dep)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -48,3 +48,8 @@ apis:
     target_api_status: alpha
     main_contacts:
       - hdamker-bot
+  - api_name: e2e-scenario-2-draft
+    target_api_version: 0.1.0
+    target_api_status: draft
+    main_contacts:
+      - hdamker-bot


### PR DESCRIPTION
Throwaway PR for VF E2E.

**Scenario 2**: Change `release-plan.yaml` only (add a draft API entry); no dependency fields touched.

Expected: `release_plan_changed=true`, `non_release_plan_files_changed=[]`, `commonalities_release_changed=false`, `icm_release_changed=false`, `release_plan_check_only=false`. Full validation runs. No P-022/P-023 findings.

Will be closed without merging.