### PR TITLE
[VF E2E Scenario 5] commonalities bogus r0.0 → P-023

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.1
+  commonalities_release: r0.0
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
Throwaway PR for VF E2E.

**Scenario 5**: Advance `dependencies.commonalities_release` from r4.1 to bogus `r0.0`.

Expected: `commonalities_release_changed=true`, `commonalities_tag_exists=false`, `release_plan_check_only=true`. Spectral + gherkin engines **skipped**. **P-023 fires error** with bogus tag name.

Will be closed without merging.