### PR TITLE
[VF E2E Scenario 6] ICM-only advance r4.1 → r4.2

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -26,7 +26,7 @@ repository:
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
   commonalities_release: r4.1
-  identity_consent_management_release: r4.1
+  identity_consent_management_release: r4.2
 
 # APIs in this repository
 # Replace the placeholder below when planning a release:


### PR DESCRIPTION
Throwaway PR for VF E2E. PR base `maintenance/scenario6-icm-base` is a throwaway branch simulating main with ICM at r4.1.

**Scenario 6**: Advance `dependencies.identity_consent_management_release` from r4.1 to r4.2 (valid tag). Commonalities unchanged.

Expected: `commonalities_release_changed=false`, `icm_release_changed=true`, `icm_tag_exists=true`, `release_plan_check_only=false` (ICM advance does NOT trigger engine suppression). **Full validation runs**. No P-022/P-023 findings.

Will be closed without merging.