### PR TITLE
[VF E2E Scenario 7] stale-base commonalities r5.1 → r4.1 revert

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r5.1
+  commonalities_release: r4.1
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
Throwaway PR for VF E2E. PR base `maintenance/scenario7-stale-base` simulates a stale main with bogus-advanced `commonalities_release: r5.1`; head reverts to `r4.1`.

**Scenario 7**: Document known over-trigger of engine suppression on stale-base revert case.

Expected: `commonalities_release_changed=true` (r5.1 → r4.1 IS a change in the diff), `commonalities_tag_exists=true` (r4.1 lookup succeeds), `release_plan_check_only=true`. **Engines suppressed** even though head-declared tag matches what `code/common/` reflects — documented as a known limitation; acceptable because a typical revert PR touches only release-plan.yaml.

Will be closed without merging.