### PR TITLE
[VF E2E Scenario 4] commonalities r4.1 → r99.99 (merge for Track C)

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.1
+  commonalities_release: r99.99
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
PR for VF E2E Scenario 4 — this one is **intended to be merged** to prep main for the Track C release cycle (which will then exercise common-sync with the new commonalities tag).

**Scenario 4**: Advance `dependencies.commonalities_release` from r4.1 to `r99.99` (a test tag on camaraproject/Commonalities created for this session, mimicking the r4.2 state; see session log).

Expected: `commonalities_release_changed=true`, `commonalities_tag_exists=true`, `release_plan_check_only=true`. Spectral + gherkin engines **skipped** (release-plan-check-only mode). Post-filter keeps only P-009/P-022/P-023. No P-023 finding (tag exists).

On merge, main declares `r99.99`; Track C `/create-snapshot` will pick it up and exercise common-sync with new commonalities artifacts.