### PR TITLE
[VF E2E Track B1] P-024 un-transformable Feature line

### DIFF
--- a/code/Test_definitions/sample-service-createResource.feature
+++ b/code/Test_definitions/sample-service-createResource.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Sample Service API, vwip - Operation: createResource
+Feature: CAMARA Sample Service API - Operation: createResource
 
   # Input to be provided by the implementation to the tests
   # References to OAS spec schemas refer to schemas specified in /code/API_definitions/sample-service.yaml


### PR DESCRIPTION
Throwaway PR for VF E2E Track B1.

**Track B1**: Remove `vwip`/`wip`/`v{version}` token entirely from a `.feature` file's `Feature:` line.

Original: `Feature: CAMARA Sample Service API, vwip - Operation: createResource`
Changed to: `Feature: CAMARA Sample Service API - Operation: createResource`

Expected: **error** with rule ID `P-024` (`check-test-file-feature-line-untransformable`). Confirms P-024's `default: error` severity is not masked by P-007's `conditional_level`.

Will be closed without merging.