### PR TITLE
[VF E2E Track B2] P-025 bare /wip scenario URL

### DIFF
--- a/code/Test_definitions/sample-service-createResource.feature
+++ b/code/Test_definitions/sample-service-createResource.feature
@@ -10,7 +10,7 @@ Feature: CAMARA Sample Service API, vwip - Operation: createResource
 
   Background: Common Sample Service createResource setup
     Given an environment at "apiRoot"
-    And the resource "/sample-service/vwip/resources"
+    And the resource "/sample-service/wip/resources"
     And the header "Authorization" is set to a valid access token
     And the header "Content-Type" is set to "application/json"
 


### PR DESCRIPTION
Throwaway PR for VF E2E Track B2.

**Track B2**: Change a scenario step URL from `/vwip` to bare `/wip`.

Edit on `code/Test_definitions/sample-service-createResource.feature` line 13:
- Before: `And the resource "/sample-service/vwip/resources"`
- After:  `And the resource "/sample-service/wip/resources"`

Expected: **error** with rule ID `P-025` (`check-feature-file-url-version`) quoting `/wip` vs expected `/vwip`.

Will be closed without merging.