### PR TITLE
cleanup: advance release-plan to r1.3, revert commonalities to r4.1

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.2
+  target_release_tag: r1.3
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r99.99
+  commonalities_release: r4.1
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
Post-E2E cleanup.

- `target_release_tag: r1.2` → `r1.3` (next alpha in the r1 cycle)
- `commonalities_release: r99.99` → `r4.1` (revert test-tag advance; a downgrade sync PR will auto-open on merge to restore code/common/ to r4.1 content)

r1.2 tag + release are retained for future reference.