### PR TITLE
[VF E2E fork-retest] Scenario 5: commonalities bogus r0.0 → P-023

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.1
+  commonalities_release: r0.0
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
Fork-PR retest after @v1-rc tag moved from 2385fd36 → eac3ce9 (now includes the Python release-plan resolver script from tooling#220).

**Scenario 5 (fork variant)**: bogus commonalities_release r0.0.

Expected: Step 9 (Python release-plan resolver) now runs successfully on the fork-PR path. `release_plan_check_only=true`, engines skipped, **P-023 fires error** with bogus tag name. PR bot comment + custom Check Run still absent on fork PR (validation App not installable on fork — by design).

Will be closed without merging.