### PR TITLE
[VF E2E fork-retest] Scenario 3: release-plan + API file → P-022

### DIFF
--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -30,6 +30,8 @@ servers:
 tags:
   - name: Resources
     description: Operations on sample resources
+  - name: Scenario3ForkTest
+    description: Placeholder tag for VF E2E Scenario 3 fork retest (will be reverted)
 security:
   - openId:
       - sample-service:resource:read

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -38,6 +38,7 @@ apis:
     target_api_status: alpha
     main_contacts:
       - hdamker-bot
+      - hdamker
   - api_name: sample-service-subscriptions
     target_api_version: 0.1.0
     target_api_status: alpha


### PR DESCRIPTION
Fork-PR retest after @v1-rc tag moved to eac3ce9 (now includes Python release-plan resolver from tooling#220).

**Scenario 3 (fork variant)**: release-plan.yaml + API YAML in same PR.

Expected: Step 7 + Step 9 both run successfully on fork-PR path. **P-022 fires error** listing the co-changed API file. Full validation runs. Annotations visible via generic github-actions Check Run. No bot comment, no custom Check Run (by design on fork PR).

Will be closed without merging.