### PR TITLE
test: short_title UI spot-check — fork PR path (do NOT merge)

### DIFF
--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Sample Service
+  title: Sample Service   
   description: |
     Template for a request-response CAMARA API.
 
@@ -14,8 +14,8 @@ info:
       - Option A: Pure `$ref` for responses using only generic error codes
       - Option B: Local response definition extending generic errors with API-specific codes
   license:
-    name: Apache 2.0
-    url: https://www.apache.org/licenses/LICENSE-2.0.html
+    name: MIT
+    url: https://opensource.org/licenses/MIT
   version: wip
   x-camara-commonalities: 0.7.0
 externalDocs:
@@ -40,7 +40,6 @@ paths:
       tags:
         - Resources
       summary: Create a resource
-      description: Creates a new resource with the provided properties.
       operationId: createResource
       parameters:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"


### PR DESCRIPTION
Throwaway **fork PR** for visual verification of [tooling#221](https://github.com/camaraproject/tooling/pull/221) (short_title field on rule metadata). **Do not merge.**

Same edits as the earlier internal PR #118 but opened from `hdamker/ReleaseTest` to exercise the fork-PR annotation path: no `camara-validation[bot]` Check Run (App can't install on forks), only the generic `github-actions` Check Run with workflow-command `::error::` annotations.

Expected short_title rendering on the **Files changed** tab popovers (title line must not wrap; body should show `[rule-id] <full message>`):

| Rule | Engine | Expected short_title | Expected length |
|---|---|---|---|
| S-018 | Spectral CAMARA custom | `License name must be 'Apache 2.0'` | 33 |
| S-019 | Spectral CAMARA custom | `License URL must be the Apache 2.0 URL` | 39 |
| S-215 | Spectral built-in OAS | `Operation must have a description` | 33 |
| Y-012 | yamllint | `Trailing whitespace` | 19 |

Close without merge once UI-verified.