### PR TITLE
test: bump commonalities_release r4.1 -> r4.2

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.1
+  commonalities_release: r4.2
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
#### What type of PR is this?

* tests

#### What this PR does / why we need it:

Bumps `release-plan.yaml` `commonalities_release` from `r4.1` to `r4.2`
to exercise the common-sync cache-freshness check against the
freshly-tagged Commonalities r4.2.

Expected: the Release Automation workflow fires on push, the sync-issue
step detects `code/common/` is stale vs. r4.2, and opens a
`sync-common/r4.2` PR.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Test PR — not for merge unless we want to keep ReleaseTest pinned to r4.2.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.

```
docs

```