### PR TITLE
chore: port sample API templates from Commonalities r4.2

### DIFF
--- a/code/API_definitions/sample-implicit-events.yaml
+++ b/code/API_definitions/sample-implicit-events.yaml
@@ -32,7 +32,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.7.0
+  x-camara-commonalities: 0.8.0-rc.2
 
 externalDocs:
   description: Product documentation at CAMARA

--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -15,7 +15,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.7.0
+  x-camara-commonalities: 0.8.0-rc.2
 
 externalDocs:
   description: Product documentation at CAMARA
@@ -127,6 +127,8 @@ paths:
       operationId: retrieveSampleServiceSubscriptionList
       parameters:
         - $ref: "../common/CAMARA_common.yaml#/components/parameters/x-correlator"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/page"
+        - $ref: "../common/CAMARA_common.yaml#/components/parameters/perPage"
       security:
         - openId:
             - sample-service-subscriptions:read
@@ -136,14 +138,17 @@ paths:
           headers:
             x-correlator:
               $ref: "../common/CAMARA_common.yaml#/components/headers/x-correlator"
+            X-Total-Count:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-total-count"
+            X-Total-Pages:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/x-total-pages"
+            Link:
+              $ref: "../common/CAMARA_common.yaml#/components/headers/link"
+
           content:
             application/json:
               schema:
-                type: array
-                minItems: 0
-                maxItems: 1000
-                items:
-                  $ref: "#/components/schemas/Subscription"
+                $ref: "#/components/schemas/SubscriptionList"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -358,6 +363,23 @@ components:
       properties:
         id:
           $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionId"
+
+    SubscriptionList:
+      description: Response with subscriptions list
+      type: object
+      required:
+        - subscriptions
+        - pagination
+      properties:
+        subscriptions:
+          description: Subscriptions list
+          type: array
+          minItems: 0
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/Subscription"
+        pagination:
+          $ref: "../common/CAMARA_common.yaml#/components/schemas/Pagination"
 
     # ─────────────────────────────────────────────────────────────────────────
     # API-specific event type enum (contains sample-service placeholders)

--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -17,7 +17,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   version: wip
-  x-camara-commonalities: 0.7.0
+  x-camara-commonalities: 0.8.0-rc.2
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/ReleaseTest


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Ports the three sample API templates in `code/API_definitions/` from the
`r4.2` release of Commonalities (`artifacts/api-templates/`):

- `sample-service.yaml`
- `sample-service-subscriptions.yaml`
- `sample-implicit-events.yaml`

Changes are limited to:

- `info.x-camara-commonalities`: `0.7.0` → `0.8.0-rc.2`
- `sample-service-subscriptions.yaml`: adopt r4.2 pagination on the
  list-subscriptions endpoint (`page` / `perPage` parameters,
  `X-Total-Count` / `X-Total-Pages` / `Link` response headers,
  `SubscriptionList` schema referencing `../common/CAMARA_common.yaml#/components/schemas/Pagination`)

Common-schema `$ref` targets verified to exist in the synced
`code/common/CAMARA_common.yaml` (already on r4.2 from #131).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

`info.url` field preserved as `https://github.com/camaraproject/ReleaseTest`
(template ships with `{apiRepository}` placeholder + replacement comment;
both replaced with the existing ReleaseTest value).

Local checks: yamllint clean; Spectral lint shows 0 errors, 11 warnings —
all `oas3-unused-component` on intentional template-stub schemas
(`EventApiSpecific1/2`, etc.) and the standard `HTTP*` casing warning.

This bump is a prerequisite for migrating the seven r4.1-line
`regression/*` branches to the r4.2 line.

#### Changelog input

```
release-note
None (test repository, not a published API).
```

#### Additional documentation

This section can be blank.

```
docs

```
