### PR TITLE
ci: repoint caller workflows from @validation-framework to @main

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -31,5 +31,5 @@ permissions:
 
 jobs:
   validation:
-    uses: camaraproject/tooling/.github/workflows/validation.yml@validation-framework
+    uses: camaraproject/tooling/.github/workflows/validation.yml@main
     secrets: inherit

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -89,5 +89,5 @@ jobs:
        github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.base.ref, 'release-snapshot/'))
 
-    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@validation-framework
+    uses: camaraproject/tooling/.github/workflows/release-automation-reusable.yml@main
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Repoints `.github/workflows/camara-validation.yml` and `.github/workflows/release-automation.yml` from `@validation-framework` to `@main` after camaraproject/tooling#260 merged.

ReleaseTest is the canary repository; pinning to `@main` (not `@v1-rc`) preserves the existing "see new tip changes immediately" semantics. Other API repositories stay on `@v1-rc`.

Step 2 of the validation-framework branch retirement tracked in camaraproject/tooling#259.

#### Which issue(s) this PR fixes:

Fixes #
(no ReleaseTest-side issue; tracked in camaraproject/tooling#259)

#### Special notes for reviewers:

Caller-workflow ref change only. No content changes elsewhere.

#### Changelog input

```
 release-note
 NONE
```

#### Additional documentation

This section can be blank.
