### PR TITLE
fix: rename S-300 to S-037 in regression-expected for schema-constraints

### DIFF
--- a/.regression/REGRESSION.md
+++ b/.regression/REGRESSION.md
@@ -25,7 +25,7 @@ and collisions are avoided by design.
 
 | # | Edit | Rule expected to fire |
 |---|---|---|
-| 1 | `ResourceId` schema changed from `type: string, format: uuid, maxLength: 36` to `type: integer, format: int64, minimum: 1, maximum: 999999`. The path parameter `resourceId` (name matches the OWASP `/(_id\|Id\|-id)$/` heuristic) now carries an integer schema. | `S-300` / `owasp:api1:2023-no-numeric-ids` (error) |
+| 1 | `ResourceId` schema changed from `type: string, format: uuid, maxLength: 36` to `type: integer, format: int64, minimum: 1, maximum: 999999`. The path parameter `resourceId` (name matches the `/(_id\|Id\|-id)$/` heuristic) now carries an integer schema. | `S-037` / `camara-no-numeric-resource-ids` (error) |
 | 2 | `email` added to `CreateResource.required` without a matching entry in `properties` | `S-030` / `camara-required-properties-exist` (warn) |
 | 3 | `maxItems: 1000` removed from the inline array schema in `GET /resources` 200 response | `S-309` / `owasp:api4:2023-array-limit` (warn) |
 | 4 | `quota: { type: integer, description: ... }` added to `CreateResource.properties` — no `format:` | `S-310` / `owasp:api4:2023-integer-format` (warn) |
@@ -35,7 +35,7 @@ and collisions are avoided by design.
 | 8 | New path `/list` (standalone reserved word as path segment) with a minimal GET operation. | `S-012` / `camara-reserved-words` (warn) |
 | 9 | Query parameter `phoneNumber` added to GET `/resources/{resourceId}`. Schema declares description, maxLength, pattern to keep S-009 / S-312 / S-313 silent. | `S-017` / `camara-security-no-secrets-in-path-or-query-parameters` (warn) |
 
-This branch tests the 10 rules listed above (S-012, S-017, S-030, S-300,
+This branch tests the 10 rules listed above (S-012, S-017, S-030, S-037,
 S-303, S-308, S-309, S-310, S-311, S-312).
 
 ### Expected cascades

--- a/.regression/regression-expected.yaml
+++ b/.regression/regression-expected.yaml
@@ -31,7 +31,7 @@ findings:
   path: code/API_definitions/sample-service-subscriptions.yaml
   level: hint
   count: 7
-- rule_id: S-300
+- rule_id: S-037
   path: code/API_definitions/sample-service.yaml
   level: error
 - rule_id: S-303


### PR DESCRIPTION
#### What type of PR is this?

* tests

#### What this PR does / why we need it:

Renames `S-300` → `S-037` in the `regression/r4.2-broken-spec-schema-constraints` expected fixture (and the matching row in `REGRESSION.md`), to track the rule retirement in [camaraproject/tooling#284](https://github.com/camaraproject/tooling/pull/284).

The underlying broken-spec edit is unchanged (integer-typed `resourceId`); only the rule identifier moves. Same path, same level, same count. The regression-runner uses `match_mode: exact`, so the fixture must rename atomically with the rule.

#### Which issue(s) this PR fixes:

Tracks camaraproject/tooling#282 / camaraproject/tooling#284.

#### Special notes for reviewers:

**Do not merge before [camaraproject/tooling#284](https://github.com/camaraproject/tooling/pull/284) lands on `tooling/main`.** Merging earlier breaks the regression-runner canary against current-main tooling (which still emits S-300 on this fixture).

Sequence:
1. Merge tooling#284 → S-037 active on `tooling/main`.
2. Merge this PR → fixture matches.
3. Next regression-runner canary on `tooling/main` push exercises both halves cleanly.

#### Changelog input

```
 release-note

```

#### Additional documentation 

```
docs

```
