### PR TITLE
chore: switch r1.6 target_release_type to pre-release-rc

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -31,4 +31,6 @@ permissions:
 jobs:
   validation:
     uses: camaraproject/tooling/.github/workflows/validation.yml@main
+    with:
+      tooling_ref_override: 85266e01032a255cd2e8d3d93e252b9844e3c106
     secrets: inherit

--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Switch `target_release_type` from `pre-release-alpha` to `pre-release-rc` for the r1.6 release cycle. Drives the canary E2E exercising every workflow change on `tooling/main` since `@v1-rc` (`e25b6486`), prior to advancing the tag. All three APIs already declared with `target_api_status: rc`, so they auto-generate `0.1.0-rc.2` on snapshot.

#### Which issue(s) this PR fixes:

<!-- E2E test cycle setup; no upstream issue tracked. -->

Fixes #

#### Special notes for reviewers:

One-line change. Caller workflows on this repo are pinned to `@main`, so subsequent `/create-snapshot` and `/publish-release` runs exercise the latest tooling tip.

#### Changelog input

```
 release-note
none
```

#### Additional documentation

This section can be blank.

```
docs

```
