### PR TITLE
chore: revert r1.6 target_release_type to pre-release-alpha

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-rc
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle


### PR DESCRIPTION
#### What type of PR is this?

repository management

#### What this PR does / why we need it:

Revert `target_release_type` back to `pre-release-alpha` for the r1.6 cycle. RC stage requires `.feature` test files for each API; two of the three sample APIs (`sample-service-subscriptions`, `sample-implicit-events`) are missing them. Reverting to alpha keeps the E2E moving without creating an incomplete RC.

The earlier `chore/r1-6-target-type-rc` PR (#166) and subsequent `/discard-snapshot` already verified the #NS-24 shell-injection fix on the discard path. Title of release issue #168 will re-render to `Release r1.6 (alpha)` after merge.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

One-line change.

#### Changelog input

```
 release-note
none
```

#### Additional documentation

This section can be blank.

```
docs

```
