### PR TITLE
experiment: bracket mandatory auth text with HTML comment delimiters in sample-service.yaml

### DIFF
--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -13,6 +13,18 @@ info:
     - Two options for error responses:
       - Option A: Pure `$ref` for responses using only generic error codes
       - Option B: Local response definition extending generic errors with API-specific codes
+
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
+
+    # Authorization and authentication
+
+    The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.
+
+    The specific authorization flows to be used will be agreed upon during the onboarding process, happening between the API consumer and the API provider, taking into account the declared purpose for accessing the API, whilst also being subject to the prevailing legal framework dictated by local legislation.
+
+    In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
+
+    <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Adds the mandatory CAMARA "Authorization and authentication" text to the `info.description` of `sample-service.yaml`, bracketed by HTML comment delimiters that name the mandatory block.

This is an exploration of a possible reference mechanism for the mandatory `info.description` sections that the Design Guide requires (today copy-pasted into every CAMARA API spec). If delimiters survive the bundling pipeline and validation untouched, they could later anchor an expansion / replacement step that pulls the canonical text from Commonalities, eliminating the cohort-wide copy-paste fan-out.

The block:

```text
<!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->

# Authorization and authentication

The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. ...

<!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
```

#### Which issue(s) this PR fixes:

<!-- Probe PR; not tied to an upstream issue. -->

Fixes #

#### Special notes for reviewers:

Pure content change. Goal is to land the snapshot/publish E2E with the delimited text in place so the bundled output and validation findings can be inspected.

#### Changelog input

```
 release-note
none
```

#### Additional documentation

This section can be blank.

```
docs

```
