### PR TITLE
chore: remove tooling_ref_override on validation caller

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -31,6 +31,4 @@ permissions:
 jobs:
   validation:
     uses: camaraproject/tooling/.github/workflows/validation.yml@main
-    with:
-      tooling_ref_override: 85266e01032a255cd2e8d3d93e252b9844e3c106
     secrets: inherit


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Remove the `tooling_ref_override` added during the manual E2E for the recent `@v1-rc` advance. With the override in place, canary regression runs on this repo would always check out the pinned tooling SHA. Removing it restores the intended behavior: regression runs use the OIDC-derived ref (the workflow's own checkout SHA), so the canary tracks the head of `camaraproject/tooling` `main`.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Two-line revert.

#### Changelog input

```
 release-note
none
```

#### Additional documentation

This section can be blank.

```
docs

```
