### PR TITLE
Disable target_release_type ahead of repository reset to r1.1 alpha

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: none
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle


### PR DESCRIPTION
Sets `target_release_type: none` ahead of repository reset to a planned r1.1 alpha state. Prevents auto-recreation of the release-issue once #174 is closed.
