### PR TITLE
Arm release-plan at r1.1 alpha to seed the reset release-issue

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,11 +16,11 @@ repository:
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.7
+  target_release_tag: r1.1
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: none
+  target_release_type: pre-release-alpha
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -35,16 +35,16 @@ dependencies:
 apis:
   - api_name: sample-service
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker-bot
   - api_name: sample-service-subscriptions
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker-bot
   - api_name: sample-implicit-events
     target_api_version: 0.1.0
-    target_api_status: rc
+    target_api_status: alpha
     main_contacts:
       - hdamker-bot


### PR DESCRIPTION
Re-arms the release-plan at `r1.1` / `pre-release-alpha` with all three sample APIs targeting `alpha` status. Completes the repository reset; merging this PR causes the workflow to create a fresh r1.1 planned release-issue.
