### PR TITLE
Pin validation caller tooling_ref_override to main (canary)

### DIFF
--- a/.github/workflows/camara-validation.yml
+++ b/.github/workflows/camara-validation.yml
@@ -31,4 +31,8 @@ permissions:
 jobs:
   validation:
     uses: camaraproject/tooling/.github/workflows/validation.yml@main
+    # Canary: pin override to `main` so fork-PR runs (no OIDC token) skip the
+    # `@v1-rc` fallback and check out tooling@main — matching push-event behaviour.
+    with:
+      tooling_ref_override: main
     secrets: inherit


### PR DESCRIPTION
Adds `tooling_ref_override: main` to the validation caller on this canary repository.

ReleaseTest pins the validation reusable workflow to `validation.yml@main` so it tracks the tip of `camaraproject/tooling`. Push events on this repo get the correct ref via OIDC. Fork PRs don't get an OIDC token and fall back to `@v1-rc` — which, whenever `main` has advanced past the tag, can break the run (e.g. missing `requirements.txt` after the recent pip-ecosystem migration).

The override now uses the named-ref allowlist landed by [tooling#290](https://github.com/camaraproject/tooling/pull/290). RA caller intentionally not changed — it is not exposed to the fork-PR-OIDC fallback (no `pull_request opened` trigger).
