### PR TITLE
Bump Commonalities dependency to r4.3

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -25,7 +25,7 @@ repository:
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
 dependencies:
-  commonalities_release: r4.2
+  commonalities_release: r4.3
   identity_consent_management_release: r4.2
 
 # APIs in this repository


### PR DESCRIPTION
#### What type of PR is this?

repository management


#### What this PR does / why we need it:

Advances `release-plan.yaml` `commonalities_release` from `r4.2` to
`r4.3` (Commonalities r4.3 published 2026-05-22). ICM dependency stays
at `r4.2` — that remains ICM's current public release.

On merge, the cache-common workflow will open a follow-up sync PR to
update `code/common/` to the r4.3 source files. The new canonical
`code/common/info-description-templates.yaml` (used by P-026..P-030 in
tooling#295) arrives in that sync PR.

Sample-spec wrapping with the BEGIN/END marker mechanism lands in a
separate PR after the sync PR merges.


#### Which issue(s) this PR fixes:

Part of #535 (RM umbrella).


#### Special notes for reviewers:

* Two-PR sequence: this bump first, then the sample-spec wrapping PR
  uses the canonical artifacts from Commonalities r4.3 directly (also
  exercises those artifacts in practice).
* `x-camara-commonalities` field on sample specs is overwritten at
  release-plan time per the existing release-automation flow — no
  manual touch needed.
