### PR TITLE
regression: add components.callbacks fixture for S-011 (tooling#296)

### DIFF
--- a/code/API_definitions/sample-implicit-events.yaml
+++ b/code/API_definitions/sample-implicit-events.yaml
@@ -73,6 +73,11 @@ paths:
             schema:
               $ref: "#/components/schemas/CreateResource"
       callbacks:
+        # Named-callback reference — exercises the tooling#296 S-011 / S-209
+        # bug shape (a Callback Object under components.callbacks). The full
+        # callback definition is at components.callbacks.onResourceEvent.
+        namedEvent:
+          $ref: "#/components/callbacks/onResourceEvent"
         notifications:
           "{$request.body#/sink}":
             post:
@@ -391,3 +396,27 @@ components:
               description: |
                 Event-specific payload for event-type2.
                 Replace with the actual data schema for this event type.
+
+  # Named callback under components.callbacks to exercise the S-011 / S-209
+  # mutual-exclusion bug fixed in tooling#296. A Callback Object is a map of
+  # runtime expressions to Path Item Objects and has no `description` field of
+  # its own; S-011 must not fire on this entry.
+  callbacks:
+    onResourceEvent:
+      "{$request.body#/sink}":
+        post:
+          summary: Named-callback fixture
+          description: |
+            Fixture for tooling#296 — named callback under components.callbacks
+            must NOT trigger S-011 (camara-properties-descriptions).
+          operationId: onResourceEventNotification
+          requestBody:
+            description: Notification body
+            required: true
+            content:
+              application/cloudevents+json:
+                schema:
+                  $ref: "#/components/schemas/ApiNotificationEvent"
+          responses:
+            "204":
+              description: Successful notification


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Adds a named-callback under `components.callbacks` to `sample-implicit-events.yaml` on the `regression/r4.2-broken-spec-descriptions` branch. Exercises the S-011 / S-209 mutual-exclusion shape from EdgeApplicationManagement so the canary catches any future regression of the JSONPath fix in tooling#296.

Today's broken-spec fixtures use only inline `paths.*.post.callbacks` (which doesn't reproduce the bug); this PR adds the missing `components.callbacks.<name>` form plus a `$ref` from the existing POST /resources operation so the component is referenced.

#### Which issue(s) this PR fixes:

Part of camaraproject/tooling#296

#### Special notes for reviewers:

- **The canary check is expected RED on initial push** and stays RED until the companion tooling PR (camaraproject/tooling#296) merges. The extra S-011 finding on the new named callback is the demonstrable proof the fixture catches the bug.
- After the tooling fix lands on `main`, a follow-up commit on this branch will recapture `.regression/regression-expected.yaml` (S-011 count stays at 3; the named callback no longer contributes). Canary will then go GREEN.

#### Changelog input

```
 release-note
test: regression fixture for tooling#296 — named callback under components.callbacks must not trigger S-011
```

#### Additional documentation

This section can be blank.

```
docs

```
