### PR TITLE
test: fork-PR fixture for tooling_ref_override named-ref allowlist (tooling#290)

### DIFF
--- a/code/API_definitions/sample-service.yaml
+++ b/code/API_definitions/sample-service.yaml
@@ -44,16 +44,6 @@ info:
     In cases where personal data is processed by the API and users can exercise their rights through mechanisms such as opt-in and/or opt-out, the use of three-legged access tokens is mandatory. This ensures that the API remains in compliance with privacy regulations, upholding the principles of transparency and user-centric privacy-by-design.
     <!-- CAMARA:MANDATORY:authorization-and-authentication:END -->
 
-    <!-- CAMARA:MANDATORY:additional-error-responses:BEGIN -->
-    # Additional CAMARA error responses
-
-    The list of error codes in this API specification is not exhaustive. Therefore the API specification MAY not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
-
-    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
-
-    As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
-    <!-- CAMARA:MANDATORY:additional-error-responses:END -->
-
     <!-- CAMARA:MANDATORY:request-body-strictness:BEGIN -->
     # Request body strictness
 


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

Fork-PR fixture for camaraproject/tooling#290 (named-ref allowlist on `tooling_ref_override`). Opening this PR from a fork exercises the path where OIDC is unavailable — the validation caller must resolve `tooling@main` via the explicit `tooling_ref_override: main` already pinned on `ReleaseTest` main, which only works after #290's allowlist landed.

Single content change: removes the mandatory `additional-error-responses` `info.description` block from `code/API_definitions/sample-service.yaml`.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Expected validation behaviour on this PR:

- **P-026** (`check-info-description-mandatory-missing`) fires on `sample-service.yaml` at `hint` level (`sample-service` is `alpha` in `release-plan.yaml`, P-026's `alpha` override).
- **P-016** would fire under tooling `@v1-rc` (existing `sinkCredential` in the `Subscription` response schema, `sample-service-subscriptions.yaml`) — muted on `@main` per camaraproject/tooling#298, so absent here. Switching the override on the branch to `tooling_ref_override: v1-rc` would surface P-016 instead, as a cross-check on the same content.

**Not for merge.**

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.

```
docs

```
