### PR TITLE
Update target release tag to r1.2

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -16,7 +16,7 @@ repository:
   # Release tag -- first release for a repository is r1.1
   # - New release cycle (increment first number, reset second to 1)
   # - Progression in same cycle (increment second number)
-  target_release_tag: r1.1
+  target_release_tag: r1.2
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release


### PR DESCRIPTION
#### What type of PR is this?

Repository Management

#### What this PR does / why we need it:

Set ReleaseTest back into `planned` state to enable regression tests.

#### Which issue(s) this PR fixes:

N/A

