### PR TITLE
test: drift code/common to exercise sync-common idempotency (#306)

### DIFF
--- a/code/common/CAMARA_common.yaml
+++ b/code/common/CAMARA_common.yaml
@@ -929,3 +929,5 @@ components:
                 status: 504
                 code: TIMEOUT
                 message: Request timeout exceeded.
+
+# e2e-drift-marker: temporary non-canonical line to force common-cache stale; removed when the sync PR is merged


### PR DESCRIPTION
Temporary E2E drift to force common-cache `stale` so the sync-common idempotent-rebuild path (tooling#306) runs against a pre-existing `sync-common/r4.3` branch.

The automated sync PR that follows restores canonical `code/common/` content; merging that sync PR reverts this change and returns `main` to canonical.
