### PR TITLE
test(e2e): trigger P-037 to verify annotation rendering (do not merge)

### DIFF
--- a/code/API_definitions/sample-service-subscriptions.yaml
+++ b/code/API_definitions/sample-service-subscriptions.yaml
@@ -326,6 +326,14 @@ components:
     Subscription:
       description: Represents a event-type subscription.
       type: object
+      x-parser-conformance-example:
+        sinkCredential: {
+          "credentialType": "ACCESSTOKEN",
+          "accessToken": "xxx",
+          "accessTokenExpiresUtc": "2024-02-17T16:23:45Z",
+          "accessTokenType": "bearer"
+        }
+        protocol: HTTP
       required:
         - sink
         - protocol


### PR DESCRIPTION
#### What type of PR is this?

tests

#### What this PR does / why we need it:

End-to-end check of the upcoming tooling `0.7.0` validation candidate. It adds a
single flow-style YAML mapping (`x-parser-conformance-example`) to the
`Subscription` schema in `sample-service-subscriptions.yaml`. That construct is
valid for tolerant parsers but is rejected by the strict `js-yaml@5` parser, so
it deterministically triggers the new `P-037` (OpenAPI YAML parser conformance)
warning.

ReleaseTest's caller pins validation to `tooling@main`, so this exercises the
release candidate end to end and lets us confirm in a real PR:

* `P-037` renders as a warning annotation on the changed file at the reported
  line, with its FAQ link.
* The annotation body keeps its colon readable (`... conformance: deficient
  indentation`).
* The fork-PR read-only-token fallback emits the finding via workflow-command
  annotations as designed.

Not for merge — this is a deliberate, throwaway defect for observation and will
be closed after the annotation is verified.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Deliberate parser-conformance defect for E2E observation only. Do not merge;
the branch will be closed and deleted after the validation run is inspected.

#### Changelog input

```
 release-note
NONE
```

#### Additional documentation

This section can be blank.
